### PR TITLE
Setup generator for memory circuits

### DIFF
--- a/cli
+++ b/cli
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
-file="$(echo build/assets/cli-*.js)"
-if test -f "${file}"; then
-	node --enable-source-maps "${file}" "$@"
-else
-	echo CLI not found. Have you built the project yet? >&2
-	echo Run: RISG_CLI=y pnpm vite build >&2
-	exit 1
-fi
+echo \> RISG_CLI=y RISG_BIGINT=y pnpm vite build >&2
+RISG_CLI=y RISG_BIGINT=y pnpm vite build >&2 || exit 1
+
+file='build/cli/index.js'
+
+echo \> node "$file" "$@" >&2
+node --enable-source-maps "$file" "$@"

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
 	},
 	"optionalDependencies": {
 		"@internal/eval-wasm": "link:eval-wasm/pkg"
+	},
+	"dependencies": {
+		"ast-types": "^0.14.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,10 @@ packageExtensionsChecksum: 119843541e5de0faa8c89f50fa62a06d
 importers:
 
   .:
+    dependencies:
+      ast-types:
+        specifier: ^0.14.2
+        version: 0.14.2
     optionalDependencies:
       '@internal/eval-wasm':
         specifier: link:eval-wasm/pkg
@@ -693,6 +697,13 @@ packages:
     resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
     engines: {node: '>=12'}
     dev: true
+
+  /ast-types@0.14.2:
+    resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
+    engines: {node: '>=4'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
@@ -2903,7 +2914,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {QuadTree} from './lib/tree.js';
 import {maybeCompress, maybeDecompress} from './lib/compress.js';
 import {
 	generateDecoder,
+	generateDemultiplexer,
 	generateEncoder,
 	generateMemory,
 	generateMultiplexer,
@@ -62,12 +63,12 @@ if (generate) {
 
 	switch (type) {
 		case 'mux': {
-			schematic = generateMultiplexer(input, output || 1n);
+			schematic = generateMultiplexer(input || output);
 			break;
 		}
 
 		case 'dem': {
-			schematic = generateMultiplexer(output || 1n, input);
+			schematic = generateDemultiplexer(output || input);
 			break;
 		}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import {
 	generateMultiplexer,
 } from './lib/generator.js';
 import {asBigInt, asNumber, parseBigInt} from './lib/bigint.js';
+import type {Schematic} from './lib/schematic.js';
 
 const {
 	values: {input, label, rate, strict, generate},
@@ -56,7 +57,7 @@ if (generate) {
 		/^(\w{3})(\d+)(?:x(\d+))?$/i.exec(generate) ?? [];
 	const input = parseBigInt(input_);
 	const output = parseBigInt(output_);
-	let schematic;
+	let schematic: Schematic;
 
 	switch (type) {
 		case 'mux': {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
 	generateEncoder,
 	generateMultiplexer,
 } from './lib/generator.js';
+import {asBigInt, asNumber, parseBigInt} from './lib/bigint.js';
 
 const {
 	values: {input, label, rate, strict, generate},
@@ -51,32 +52,32 @@ const {
 });
 
 if (generate) {
-	const [, type, input_, output_ = '0'] =
+	const [, type, input_ = '0', output_ = '0'] =
 		/^(\w{3})(\d+)(?:x(\d+))?$/i.exec(generate) ?? [];
-	const input = Number(input_);
-	const output = Number(output_);
+	const input = parseBigInt(input_);
+	const output = parseBigInt(output_);
 	let schematic;
 
 	switch (type) {
 		case 'mux': {
-			schematic = generateMultiplexer(input, output || 1);
+			schematic = generateMultiplexer(input, output || 1n);
 			break;
 		}
 
 		case 'dem': {
-			schematic = generateMultiplexer(output || 1, input);
+			schematic = generateMultiplexer(output || 1n, input);
 			break;
 		}
 
 		case 'dec': {
-			schematic = generateDecoder(input, output || 2 ** input);
+			schematic = generateDecoder(input, output || 2n ** input);
 			break;
 		}
 
 		case 'enc': {
 			schematic = generateEncoder(
 				input,
-				output || Math.ceil(Math.log2(input)),
+				output || asBigInt(Math.ceil(Math.log2(asNumber(input)))),
 			);
 			break;
 		}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {maybeCompress, maybeDecompress} from './lib/compress.js';
 import {
 	generateDecoder,
 	generateEncoder,
+	generateMemory,
 	generateMultiplexer,
 } from './lib/generator.js';
 import {asBigInt, asNumber, parseBigInt} from './lib/bigint.js';
@@ -80,6 +81,11 @@ if (generate) {
 				input,
 				output || asBigInt(Math.ceil(Math.log2(asNumber(input)))),
 			);
+			break;
+		}
+
+		case 'mem': {
+			schematic = generateMemory(input, output || 8n);
 			break;
 		}
 

--- a/src/component/dialog/entry.ts
+++ b/src/component/dialog/entry.ts
@@ -20,7 +20,7 @@ export function setup() {
 		}
 
 		if (dialogEntry.returnValue) {
-			resolve?.(Number(dialogEntry.returnValue));
+			resolve?.(Number.parseInt(dialogEntry.returnValue, 10));
 		} else {
 			reject?.(new Error('Paste dialog closed'));
 		}

--- a/src/component/dialog/menu.ts
+++ b/src/component/dialog/menu.ts
@@ -8,6 +8,7 @@ import * as selection from '../selection.js';
 import * as storage from '../storage.js';
 import {Schematic} from '../../lib/schematic.js';
 import {maybeCompress, maybeDecompress} from '../../lib/compress.js';
+import {toBigInt} from '../../lib/bigint.js';
 import * as dialogBrowse from './browse.js';
 import * as dialogLoad from './load.js';
 import * as dialogSave from './save.js';
@@ -57,7 +58,7 @@ export function setup() {
 	});
 
 	inputMajorGrid.addEventListener('input', () => {
-		grid.setMajorGridLength(BigInt(inputMajorGrid.valueAsNumber || 0n));
+		grid.setMajorGridLength(toBigInt(inputMajorGrid.valueAsNumber || 0));
 	});
 
 	inputEvalRate.addEventListener('input', () => {

--- a/src/component/dialog/monitor.ts
+++ b/src/component/dialog/monitor.ts
@@ -40,14 +40,15 @@ export function setup() {
 			child.remove();
 		}
 
-		const {context} = eval_;
-		if (!(context instanceof SequencerContext)) return;
+		if (!(eval_.context instanceof SequencerContext)) return;
 
-		for (const tile of context.monitoredTiles) {
+		for (const tile of eval_.context.monitoredTiles) {
 			// Cast safety: monitoredTiles is a subset of TilesMap.ioTiles.
 			// tileNames also contains a mapping for every item in TilesMap.ioTiles.`
-			// eslint-disable-next-line @internal/no-object-literals
-			headerRow.append(create('th', {}, context.tileNames.get(tile)!));
+			headerRow.append(
+				// eslint-disable-next-line @internal/no-object-literals
+				create('th', {}, eval_.context.tileNames.get(tile)!),
+			);
 		}
 	});
 

--- a/src/component/dialog/screenshot.ts
+++ b/src/component/dialog/screenshot.ts
@@ -10,6 +10,7 @@ import * as theme from '../theme.js';
 import * as tree from '../tree.js';
 import * as selection from '../selection.js';
 import {Timeout} from '../../lib/timer.js';
+import {asNumber} from '../../lib/bigint.js';
 
 const dialogScreenshot = query('#dialog-screenshot', HTMLDialogElement);
 const screenshotForm = query('form', HTMLFormElement, dialogScreenshot);
@@ -32,8 +33,8 @@ function setupScreenshotOverrides() {
 	tree.setScale(inputScale.valueAsNumber);
 	useDip = inputDip.checked;
 	document.body.classList.toggle('dark', inputDark.checked);
-	canvas.canvas.width = Number(inputWidth.value);
-	canvas.canvas.height = Number(inputHeight.value);
+	canvas.canvas.width = inputWidth.valueAsNumber;
+	canvas.canvas.height = inputHeight.valueAsNumber;
 	theme.updateStylesFromCss();
 }
 
@@ -123,8 +124,8 @@ export function open(target?: 'selection') {
 		const box = selection.getBox();
 		inputX.value = String(box.topLeft.x);
 		inputY.value = String(box.topLeft.y);
-		inputWidth.value = String(realScale * Number(box.width));
-		inputHeight.value = String(realScale * Number(box.height));
+		inputWidth.value = String(realScale * asNumber(box.width));
+		inputHeight.value = String(realScale * asNumber(box.height));
 	} else {
 		inputX.value = tree.scrollX.toString();
 		inputY.value = tree.scrollY.toString();

--- a/src/component/dialog/sequence-failed.ts
+++ b/src/component/dialog/sequence-failed.ts
@@ -32,7 +32,7 @@ export function open(errors: readonly SequencerError[]) {
 					class: 'error',
 				},
 				create('span', {class: 'message'}, i.rawMessage),
-				create('span', {class: 'lineno'}, String(i.line.index + 1)),
+				create('span', {class: 'lineno'}, String(i.line.index + 1n)),
 				create('pre', {class: 'line'}, String(i.line.content)),
 			),
 		),

--- a/src/component/grid.ts
+++ b/src/component/grid.ts
@@ -1,3 +1,4 @@
+import {parseBigInt} from '../lib/bigint.js';
 import * as storage from './storage.js';
 
 const configMinorGrid = 'minor-grid';
@@ -28,6 +29,8 @@ export function setup() {
 		Boolean(storage.getString(configMinorGrid, storage.configPrefix)),
 	);
 	setMajorGridLength(
-		BigInt(storage.getString(configMajorGrid, storage.configPrefix, 0n)),
+		parseBigInt(
+			storage.getString(configMajorGrid, storage.configPrefix, '0'),
+		),
 	);
 }

--- a/src/component/renderer.ts
+++ b/src/component/renderer.ts
@@ -4,6 +4,7 @@ import * as searchMode from '../lib/search-mode.js';
 import * as tileType from '../lib/tile-type.js';
 import {WalkStep} from '../lib/walk.js';
 import type {QuadTreeNode} from '../lib/node.js';
+import {asBigInt, asNumber, toBigInt} from '../lib/bigint.js';
 import * as canvas from './canvas.js';
 import * as screenshot from './dialog/screenshot.js';
 import * as eval_ from './eval.js';
@@ -34,9 +35,7 @@ export function setup() {
 }
 
 function getScaleIntOffset(point: number, oldScale: number) {
-	return BigInt(
-		Math.trunc(point / oldScale) - Math.trunc(point / tree.scale),
-	);
+	return toBigInt(point / oldScale) - toBigInt(point / tree.scale);
 }
 
 function getScaleFloatOffset(point: number, oldScale: number) {
@@ -74,14 +73,10 @@ function commitInputs() {
 	) {
 		const x =
 			tree.scrollX.bigint +
-			BigInt(
-				Math.trunc(pointer.centerX / tree.scale + tree.scrollX.float),
-			);
+			toBigInt(pointer.centerX / tree.scale + tree.scrollX.float);
 		const y =
 			tree.scrollY.bigint +
-			BigInt(
-				Math.trunc(pointer.centerY / tree.scale + tree.scrollY.float),
-			);
+			toBigInt(pointer.centerY / tree.scale + tree.scrollY.float);
 
 		if (pointer.wasSelecting) {
 			selection.setSecondPosition(x, y);
@@ -98,17 +93,9 @@ function commitInputs() {
 	} else if (pointer.hasClicked) {
 		const currentPoint = new Point(
 			tree.scrollX.bigint +
-				BigInt(
-					Math.trunc(
-						pointer.centerX / tree.scale + tree.scrollX.float,
-					),
-				),
+				toBigInt(pointer.centerX / tree.scale + tree.scrollX.float),
 			tree.scrollY.bigint +
-				BigInt(
-					Math.trunc(
-						pointer.centerY / tree.scale + tree.scrollY.float,
-					),
-				),
+				toBigInt(pointer.centerY / tree.scale + tree.scrollY.float),
 		);
 
 		switch (mode.mode) {
@@ -213,8 +200,8 @@ function onFrame(ms: DOMHighResTimeStamp) {
 
 	const display = new AxisAlignedBoundingBox(
 		new Point(tree.scrollX.bigint, tree.scrollY.bigint),
-		BigInt(Math.ceil(width / realScale) + 1),
-		BigInt(Math.ceil(height / realScale) + 1),
+		asBigInt(Math.ceil(width / realScale) + 1),
+		asBigInt(Math.ceil(height / realScale) + 1),
 	);
 
 	const progress: WalkStep[] = [
@@ -254,8 +241,8 @@ function onFrame(ms: DOMHighResTimeStamp) {
 			continue;
 		}
 
-		const i = Number(node.bounds.topLeft.x - tree.scrollX.bigint);
-		const j = Number(node.bounds.topLeft.y - tree.scrollY.bigint);
+		const i = asNumber(node.bounds.topLeft.x - tree.scrollX.bigint);
+		const j = asNumber(node.bounds.topLeft.y - tree.scrollY.bigint);
 
 		if (node.type === tileType.branch) {
 			progress.push(new WalkStep(node[index]));
@@ -297,22 +284,18 @@ function onFrame(ms: DOMHighResTimeStamp) {
 				: new AxisAlignedBoundingBox(
 						new Point(
 							tree.scrollX.bigint +
-								BigInt(
-									Math.trunc(
-										pointer.centerX / tree.scale +
-											tree.scrollX.float,
-									),
+								toBigInt(
+									pointer.centerX / tree.scale +
+										tree.scrollX.float,
 								),
 							tree.scrollY.bigint +
-								BigInt(
-									Math.trunc(
-										pointer.centerY / tree.scale +
-											tree.scrollY.float,
-									),
+								toBigInt(
+									pointer.centerY / tree.scale +
+										tree.scrollY.float,
 								),
 						),
-						BigInt(selection.clipboard?.realWidth ?? 0),
-						BigInt(selection.clipboard?.realHeight ?? 0),
+						selection.clipboard?.realWidth ?? 0n,
+						selection.clipboard?.realHeight ?? 0n,
 				  );
 		const x = convertAxisToDisplayCoordinate(
 			box.topLeft.x,
@@ -383,7 +366,7 @@ function convertAxisToDisplayCoordinate(
 	max: number,
 ) {
 	return clampDisplayCoordinate(
-		Number(axisValue - scrollAxis) * realScale - offset,
+		asNumber(axisValue - scrollAxis) * realScale - offset,
 		max,
 	);
 }
@@ -400,7 +383,7 @@ function convertSizeToDisplayCoordinate(
 ) {
 	return (
 		clampDisplayCoordinate(
-			Number(axisValue + sizeValue - scrollAxis) * realScale - offset,
+			asNumber(axisValue + sizeValue - scrollAxis) * realScale - offset,
 			max,
 		) - axisDisplay
 	);
@@ -437,23 +420,23 @@ function drawGrid(
 		canvas.context.lineWidth = majorGridStrokeWidth * dip;
 		canvas.context.beginPath();
 
-		for (let dx = 1; dx <= display.width; dx++) {
-			if (
-				(tree.scrollX.bigint + BigInt(dx)) % grid.majorGridLength ===
-				0n
-			) {
-				canvas.context.moveTo(dx * realScale - offsetX, 0);
-				canvas.context.lineTo(dx * realScale - offsetX, height);
+		for (let dx = 1n; dx <= display.width; dx++) {
+			if ((tree.scrollX.bigint + dx) % grid.majorGridLength === 0n) {
+				canvas.context.moveTo(asNumber(dx) * realScale - offsetX, 0);
+				canvas.context.lineTo(
+					asNumber(dx) * realScale - offsetX,
+					height,
+				);
 			}
 		}
 
-		for (let dy = 1; dy <= display.height; dy++) {
-			if (
-				(tree.scrollY.bigint + BigInt(dy)) % grid.majorGridLength ===
-				0n
-			) {
-				canvas.context.moveTo(0, dy * realScale - offsetY);
-				canvas.context.lineTo(width, dy * realScale - offsetY);
+		for (let dy = 1n; dy <= display.height; dy++) {
+			if ((tree.scrollY.bigint + dy) % grid.majorGridLength === 0n) {
+				canvas.context.moveTo(0, asNumber(dy) * realScale - offsetY);
+				canvas.context.lineTo(
+					width,
+					asNumber(dy) * realScale - offsetY,
+				);
 			}
 		}
 

--- a/src/component/selection.ts
+++ b/src/component/selection.ts
@@ -59,10 +59,7 @@ export function copy() {
 
 export function remove() {
 	const {width, height} = getBox();
-	tree.tree.putSchematic(
-		new Schematic(Number(width), Number(height), []),
-		getBox().topLeft,
-	);
+	tree.tree.putSchematic(new Schematic(width, height, []), getBox().topLeft);
 }
 
 export function cut() {
@@ -76,7 +73,7 @@ export function paste(point: Point) {
 	tree.tree.putSchematic(clipboard, point);
 	firstX = point.x;
 	firstY = point.y;
-	secondX = firstX + BigInt(clipboard.realWidth) - 1n;
-	secondY = firstY + BigInt(clipboard.realHeight) - 1n;
+	secondX = firstX + clipboard.realWidth - 1n;
+	secondY = firstY + clipboard.realHeight - 1n;
 	cachedBox = undefined;
 }

--- a/src/component/tree.ts
+++ b/src/component/tree.ts
@@ -5,7 +5,7 @@ import * as tileType from '../lib/tile-type.js';
 import {QuadTree} from '../lib/tree.js';
 import * as dialogSequence from './dialog/sequence.js';
 
-const defaultTree = new Schematic(5, 5, [
+const defaultTree = new Schematic(5n, 5n, [
 	tileType.empty,
 	tileType.empty,
 	tileType.io,

--- a/src/component/version.ts
+++ b/src/component/version.ts
@@ -15,11 +15,11 @@ export async function setup() {
 	if (!storage.localStorageAvailable) return;
 
 	if (
-		Number(previousVersion[0]) !== Number(currentSaveVersion[0]) ||
-		Number(previousVersion[1]) > Number(currentSaveVersion[1])
+		previousVersion[0] !== currentSaveVersion[0] ||
+		(previousVersion[1] ?? 0) > currentSaveVersion[1]
 	) {
 		dialogIncompatible.open();
-	} else if (Number(previousVersion[1]) !== Number(currentSaveVersion[1])) {
+	} else if (previousVersion[1] !== currentSaveVersion[1]) {
 		await upgradePrefix(storage.savePrefix, QuadTree.from);
 		await upgradePrefix(storage.schematicPrefix, Schematic.from);
 

--- a/src/lib/aabb.ts
+++ b/src/lib/aabb.ts
@@ -1,5 +1,5 @@
 import {assert, assertObject} from './assert.js';
-import {isPowerOfTwo} from './bigint.js';
+import {asBigInt, isPowerOfTwo, parseBigInt, toBigInt} from './bigint.js';
 import {Point} from './point.js';
 
 /**
@@ -76,11 +76,11 @@ export class QuadTreeBoundingBox extends AxisAlignedBoundingBox {
 		assert(typeof value.y === 'string');
 		assert(typeof value.w === 'string');
 
-		const w = BigInt(value.w);
+		const w = parseBigInt(value.w);
 		assert(isPowerOfTwo(w));
 
 		return new QuadTreeBoundingBox(
-			new Point(BigInt(value.x), BigInt(value.y)),
+			new Point(parseBigInt(value.x), parseBigInt(value.y)),
 			w,
 		);
 	}
@@ -99,7 +99,7 @@ export class QuadTreeBoundingBox extends AxisAlignedBoundingBox {
 	 * {@link QuadTree} somewhat centered, we will grow it either down-right or
 	 * up-left depending on its parity.
 	 *
-	 * @param parity Equal to `Math.log2(Number(this.width)) % 2 === 0`. Since
+	 * @param parity Equal to `Math.log2(asNumber(this.width)) % 2 === 0`. Since
 	 * we cannot use {@link Math.log2} directly on a {@link BigInt}, we will
 	 * just start at `false` for the origin and invert at each step.
 	 */
@@ -125,8 +125,8 @@ export class QuadTreeBoundingBox extends AxisAlignedBoundingBox {
 
 		return new QuadTreeBoundingBox(
 			new Point(
-				this.topLeft.x + subWidth * BigInt(childIndex % 2),
-				this.topLeft.y + subWidth * BigInt(Math.trunc(childIndex / 2)),
+				this.topLeft.x + subWidth * asBigInt(childIndex % 2),
+				this.topLeft.y + subWidth * toBigInt(childIndex / 2),
 			),
 			subWidth,
 		);

--- a/src/lib/bigint.ts
+++ b/src/lib/bigint.ts
@@ -1,5 +1,101 @@
 import {assert} from './assert.js';
 
+/**
+ * Convert an integral {@link Number} into a {@link BigInt}. It is undefined
+ * behavior for the number to be non-integral. Use {@link toBigInt} instead if
+ * the value might be non-integral.
+ *
+ * Note: This function is a No-Op if BigInt-to-Number conversion is enabled. In
+ * fact, calls to any function named `asBigInt` will be stripped, and only the
+ * argument will remain.
+ */
+// eslint-disable-next-line unicorn/prefer-native-coercion-functions
+export function asBigInt(value: number) {
+	return BigInt(value);
+}
+
+/**
+ * Convert a {@link BigInt} into an integral {@link Number}.
+ *
+ * Note: This function is a No-Op if BigInt-to-Number conversion is enabled. In
+ * fact, calls to any function named `asNumber` will be stripped, and only the
+ * argument will remain.
+ */
+// eslint-disable-next-line unicorn/prefer-native-coercion-functions
+export function asNumber(value: bigint) {
+	return Number(value);
+}
+
+/**
+ * Parse a {@link String} into a decimal {@link BigInt}.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `parseBigInt` will be inlined into a {@link Number.parseInt} call with a
+ * radix of 10.
+ */
+export function parseBigInt(value: string) {
+	return RISG_BIGINT ? BigInt(value) : asBigInt(Number.parseInt(value, 10));
+}
+
+/**
+ * Truncate a {@link Number} into a {@link BigInt}. If given a {@link BigInt},
+ * it will return it without modification.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `toBigInt` will be inlined into a {@link Math.trunc} call.
+ */
+export function toBigInt(value: bigint | number) {
+	return typeof value === 'bigint' ? value : asBigInt(Math.trunc(value));
+}
+
+/**
+ * Convert a {@link Number} into a fixed-point {@link BigInt} with a given
+ * precision.
+ */
+export function toFixedPoint(number: number, precision: bigint) {
+	return toBigInt(number * 10 ** asNumber(precision));
+}
+
+/**
+ * Returns the {@link Math.abs absolute value} of a {@link BigInt}.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `absBigInt` will be inlined into a {@link Math.abs} call.
+ */
+export function absBigInt(value: bigint) {
+	return value < 0n ? -value : value;
+}
+
+/**
+ * Returns the {@link Math.max maximum} of two {@link BigInt}s.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `maxBigInt` will be inlined into a {@link Math.max} call.
+ */
+export function maxBigInt(a: bigint, b: bigint) {
+	return a < b ? b : a;
+}
+
+/**
+ * Returns the {@link Math.min minimum} of two {@link BigInt}s.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `minBigInt` will be inlined into a {@link Math.min} call.
+ */
+export function minBigInt(a: bigint, b: bigint) {
+	return a < b ? a : b;
+}
+
+/**
+ * Returns the {@link Math.sign sign} of two {@link BigInt}s.
+ *
+ * Note: If BigInt-to-Number conversion is enabled, calls to any function named
+ * `signBigInt` will be inlined into a {@link Math.sign} call.
+ */
+export function signBigInt(value: bigint) {
+	return value > 0n ? 1n : value < 0n ? -1n : 0n;
+}
+
 /** @see https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2 */
 export function isPowerOfTwo(value: bigint) {
 	// eslint-disable-next-line no-bitwise
@@ -8,11 +104,7 @@ export function isPowerOfTwo(value: bigint) {
 
 /** @see https://golb.hplar.ch/2018/09/javascript-bigint.html */
 export function roundedSqrt(value: bigint) {
-	if (typeof value === 'bigint') {
-		// This branch is only used if the bigint to number conversion is
-		// disabled. Otherwise, this entire branch will be treeshaked in favor
-		// of the much simpler and faster version below.
-
+	if (RISG_BIGINT) {
 		assert(value >= 0n);
 		let o = 0n;
 		let x = value;
@@ -26,7 +118,5 @@ export function roundedSqrt(value: bigint) {
 		return x;
 	}
 
-	// Cast safety: This branch is used if the bigint to number conversion
-	// is enabled. Since TypeScript does not know about that, we lie to it.
-	return Math.round(Math.sqrt(value)) as never;
+	return asBigInt(Math.round(Math.sqrt(asNumber(value))));
 }

--- a/src/lib/floating-bigint.ts
+++ b/src/lib/floating-bigint.ts
@@ -1,10 +1,4 @@
-function toFixedPoint(number: number, precision: number) {
-	return Math.trunc(number * 10 ** precision);
-}
-
-function abs(int: bigint) {
-	return int < 0 ? -int : int;
-}
+import {absBigInt, parseBigInt, toBigInt, toFixedPoint} from './bigint.js';
 
 export class FloatingBigInt {
 	constructor(
@@ -18,7 +12,7 @@ export class FloatingBigInt {
 		}
 
 		if (this.float < 0 || this.float >= 1) {
-			this.bigint += BigInt(Math.trunc(this.float));
+			this.bigint += toBigInt(this.float);
 			this.float %= 1;
 
 			if (this.float < 0) {
@@ -41,23 +35,23 @@ export class FloatingBigInt {
 				decimal?: string;
 			};
 
-			this.bigint = BigInt(sign + bigint);
+			this.bigint = parseBigInt(sign + bigint);
 			this.float = decimal ? Number.parseFloat(`${sign}0${decimal}`) : 0;
 		} else {
-			this.float = Number(text);
+			this.float = Number.parseFloat(text);
 		}
 
 		this.normalize();
 	}
 
-	toString(precision = 1) {
+	toString(precision = 1n) {
 		this.normalize();
 
 		const fixed = toFixedPoint(this.float, precision);
-		if (fixed === 0) return String(this.bigint);
+		if (fixed === 0n) return String(this.bigint);
 		if (this.bigint >= 0) return `${this.bigint}.${fixed}`;
 
-		return `-${abs(this.bigint + 1n)}.${toFixedPoint(
+		return `-${absBigInt(this.bigint + 1n)}.${toFixedPoint(
 			1 - this.float,
 			precision,
 		)}`;

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -1,6 +1,6 @@
 import {AxisAlignedBoundingBox} from './aabb.js';
-import {nonNullable, assert} from './assert.js';
-import {asBigInt, asNumber, maxBigInt, minBigInt, toBigInt} from './bigint.js';
+import {assert, nonNullable} from './assert.js';
+import {asBigInt, asNumber, toBigInt} from './bigint.js';
 import {Point} from './point.js';
 import {Schematic} from './schematic.js';
 import * as tileType from './tile-type.js';

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -8,8 +8,8 @@ function drawTile(
 	y: number,
 	tile: tileType.QuadTreeTileType,
 ) {
-	assert(x > 0 && x < schematic.width);
-	assert(y > 0 && y < schematic.height);
+	assert(x >= 0 && x < schematic.width);
+	assert(y >= 0 && y < schematic.height);
 	schematic.tiles[y * schematic.width + x] = tile;
 }
 

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -439,6 +439,48 @@ const memoryDecoderTrue = new GenerationContext(4n, 8n, [
 	tileType.negate,
 ]);
 
+const memoryDecoderControlRw = new GenerationContext(4n, 8n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinN,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinS,
+	tileType.disjoinN,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
 const memoryDecoderControl = new GenerationContext(7n, 8n, [
 	tileType.empty,
 	tileType.conjoinS,
@@ -836,6 +878,7 @@ export function generateMemory(address: bigint, data: bigint) {
 		}
 
 		row.push(
+			memoryDecoderControlRw,
 			memoryDecoderControl,
 			memoryDecoderNegate,
 			GenerationContext.repeatSchematicFor(memoryCell, data, 1n),
@@ -849,7 +892,7 @@ export function generateMemory(address: bigint, data: bigint) {
 			new GenerationContext(1n, 3n),
 			GenerationContext.repeatSchematicFor(
 				gridVerticalDoubleInput,
-				address,
+				address + 1n,
 				1n,
 			),
 			GenerationContext.repeatSchematicFor(
@@ -867,7 +910,7 @@ export function generateMemory(address: bigint, data: bigint) {
 			0n,
 			0n,
 			1n +
-				gridVerticalDoubleInput.realWidth * address +
+				gridVerticalDoubleInput.realWidth * (address + 1n) +
 				gridVerticalSingleInput.realWidth * 3n +
 				2n,
 		),

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -298,6 +298,17 @@ const gridNegate = new GenerationContext(1n, 2n, [
 	tileType.negate,
 ]);
 
+const gridVerticalSingleInput = new GenerationContext(2n, 3n, [
+	tileType.empty,
+	tileType.io,
+
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+]);
+
 const gridVerticalDoubleInput = new GenerationContext(4n, 3n, [
 	tileType.empty,
 	tileType.empty,
@@ -314,6 +325,283 @@ const gridVerticalDoubleInput = new GenerationContext(4n, 3n, [
 	tileType.empty,
 	tileType.negate,
 ]);
+
+const memoryDataInput = new GenerationContext(8n, 3n, [
+	tileType.empty,
+	tileType.io,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.negate,
+]);
+
+const memoryDecoderFalse = new GenerationContext(4n, 8n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinN,
+	tileType.disjoinN,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinS,
+	tileType.disjoinN,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
+const memoryDecoderTrue = new GenerationContext(4n, 8n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinN,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinS,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
+const memoryDecoderControl = new GenerationContext(7n, 8n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinN,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinS,
+	tileType.disjoinN,
+	tileType.disjoinE,
+	tileType.disjoinN,
+	tileType.empty,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+]);
+
+const memoryDecoderNegate = new GenerationContext(1n, 8n, [
+	tileType.empty,
+	tileType.negate,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.negate,
+]);
+
+const memoryCell = new GenerationContext(8n, 8n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.conjoinE,
+	tileType.disjoinW,
+	tileType.disjoinW,
+	tileType.disjoinW,
+	tileType.negate,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.conjoinE,
+	tileType.disjoinW,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinS,
+	tileType.negate,
+	tileType.conjoinW,
+	tileType.conjoinW,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinE,
+	tileType.conjoinN,
+	tileType.empty,
+	tileType.negate,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.conjoinN,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinE,
+	tileType.conjoinN,
+	tileType.empty,
+	tileType.conjoinN,
+	tileType.empty,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.disjoinW,
+	tileType.conjoinE,
+	tileType.disjoinW,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
+const memoryOutput = GenerationContext.pad(
+	new GenerationContext(1n, 4n, [
+		tileType.conjoinS,
+		tileType.negate,
+		tileType.conjoinS,
+		tileType.io,
+	]),
+	0n,
+	0n,
+	0n,
+	7n,
+);
 
 function drawGrid(activation: boolean[][]) {
 	const activationMapped = activation.map((row, index, {length}) => {
@@ -548,5 +836,58 @@ export function generateEncoder(input: bigint, output: bigint) {
 			dataIn.realWidth,
 		),
 		GenerationContext.horizontalJoin(dataIn, grid, dataOut),
+	);
+}
+
+export function generateMemory(address: bigint, data: bigint) {
+	const p = 2n ** address;
+	const rows = [];
+
+	for (let i = 0n; i < p; i++) {
+		const row = [];
+
+		row.push(memoryDecoderNegate);
+
+		for (let j = 0n; j < address; j++) {
+			// eslint-disable-next-line no-bitwise
+			row.push(i & (1n << j) ? memoryDecoderTrue : memoryDecoderFalse);
+		}
+
+		row.push(
+			memoryDecoderControl,
+			memoryDecoderNegate,
+			GenerationContext.repeatSchematicFor(memoryCell, data, 1n),
+		);
+
+		rows.push(GenerationContext.horizontalJoin(...row));
+	}
+
+	return GenerationContext.verticalJoin(
+		GenerationContext.horizontalJoin(
+			new GenerationContext(1n, 3n),
+			GenerationContext.repeatSchematicFor(
+				gridVerticalDoubleInput,
+				address,
+				1n,
+			),
+			GenerationContext.repeatSchematicFor(
+				gridVerticalSingleInput,
+				3n,
+				1n,
+			),
+			new GenerationContext(2n, 3n),
+			GenerationContext.repeatSchematicFor(memoryDataInput, data, 1n),
+		),
+		...rows,
+		GenerationContext.pad(
+			GenerationContext.repeatSchematicFor(memoryOutput, data, 1n),
+			0n,
+			0n,
+			0n,
+			1n +
+				gridVerticalDoubleInput.realWidth * address +
+				gridVerticalSingleInput.realWidth * 3n +
+				2n,
+		),
 	);
 }

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -1,174 +1,423 @@
+import {AxisAlignedBoundingBox} from './aabb.js';
 import {nonNullable, assert} from './assert.js';
 import {asBigInt, asNumber, maxBigInt, minBigInt, toBigInt} from './bigint.js';
+import {Point} from './point.js';
 import {Schematic} from './schematic.js';
 import * as tileType from './tile-type.js';
 
-function drawTile(
-	schematic: Schematic,
-	x: bigint,
-	y: bigint,
-	tile: tileType.QuadTreeTileType,
-) {
-	assert(x >= 0 && x < schematic.width);
-	assert(y >= 0 && y < schematic.height);
-	schematic.tiles[asNumber(y * schematic.width + x)] = tile;
+class AnchorBox extends AxisAlignedBoundingBox {
+	getTop() {
+		return new Point(
+			this.topLeft.x + toBigInt(this.width / 2n),
+			this.topLeft.y,
+		);
+	}
+
+	getTopRight() {
+		return new Point(this.topLeft.x + this.width - 1n, this.topLeft.y);
+	}
+
+	getRight() {
+		return new Point(
+			this.topLeft.x + this.width - 1n,
+			this.topLeft.y + toBigInt(this.height / 2n),
+		);
+	}
+
+	getBottom() {
+		return new Point(
+			this.topLeft.x + toBigInt(this.width / 2n),
+			this.topLeft.y + this.height - 1n,
+		);
+	}
+
+	getBottomLeft() {
+		return new Point(this.topLeft.x, this.topLeft.y + this.height - 1n);
+	}
+
+	getLeft() {
+		return new Point(
+			this.topLeft.x,
+			this.topLeft.y + toBigInt(this.height / 2n),
+		);
+	}
+
+	getCenter() {
+		return new Point(
+			this.topLeft.x + toBigInt(this.width / 2n),
+			this.topLeft.y + toBigInt(this.height / 2n),
+		);
+	}
+
+	pad(top = 1n, right = top, bottom = top, left = right) {
+		return new AnchorBox(
+			new Point(this.topLeft.x - left, this.topLeft.y - top),
+			this.width + left + right,
+			this.height + top + bottom,
+		);
+	}
 }
 
-function drawGrid(
-	schematic: Schematic,
-	activation: boolean[][],
-	xOffset: bigint,
-	yOffset: bigint,
-) {
-	const p = asBigInt(activation.length);
-	const q = asBigInt(nonNullable(activation[0]).length);
+class GenerationContext extends Schematic {
+	static repeatTileFor(
+		tile: tileType.QuadTreeTileType | tileType.QuadTreeTileType[],
+		columns: bigint,
+		rows: bigint,
+	) {
+		assert(
+			!Array.isArray(tile) || tile.length === asNumber(rows * columns),
+		);
 
+		const context = new GenerationContext(columns, rows);
+
+		for (let y = 0n; y < rows; y++) {
+			for (let x = 0n; x < columns; x++) {
+				context.drawTile(
+					Array.isArray(tile)
+						? nonNullable(tile[asNumber(x + y * columns)])
+						: tile,
+					new Point(x, y),
+				);
+			}
+		}
+
+		return context;
+	}
+
+	static repeatSchematicFor(
+		schematic: Schematic | Schematic[],
+		columns: bigint,
+		rows: bigint,
+	) {
+		assert(
+			!Array.isArray(schematic) ||
+				schematic.length === asNumber(rows * columns),
+		);
+
+		const {realWidth, realHeight} = Array.isArray(schematic)
+			? nonNullable(schematic[0])
+			: schematic;
+
+		const context = new GenerationContext(
+			columns * realWidth,
+			rows * realHeight,
+		);
+
+		for (let y = 0n; y < rows; y++) {
+			for (let x = 0n; x < columns; x++) {
+				const currentSchematic = Array.isArray(schematic)
+					? nonNullable(schematic[asNumber(x + y * columns)])
+					: schematic;
+
+				assert(
+					currentSchematic.realWidth === realWidth &&
+						currentSchematic.realHeight === realHeight,
+				);
+
+				context.drawSchematic(
+					currentSchematic,
+					new Point(x * realWidth, y * realHeight),
+				);
+			}
+		}
+
+		return context;
+	}
+
+	static verticalJoin(...schematics: Schematic[]) {
+		const realWidth = nonNullable(schematics[0]).realWidth;
+		const realHeight = schematics.reduce((a, b) => a + b.realHeight, 0n);
+		const context = new GenerationContext(realWidth, realHeight);
+		let lastPoint = context.bounds.topLeft;
+
+		for (const schematic of schematics) {
+			assert(schematic.realWidth === realWidth);
+			lastPoint = context
+				.drawSchematic(schematic, lastPoint)
+				.pad(1n, 0n)
+				.getBottomLeft();
+		}
+
+		return context;
+	}
+
+	static horizontalJoin(...schematics: Schematic[]) {
+		const realWidth = schematics.reduce((a, b) => a + b.realWidth, 0n);
+		const realHeight = nonNullable(schematics[0]).realHeight;
+		const context = new GenerationContext(realWidth, realHeight);
+		let lastPoint = context.bounds.topLeft;
+
+		for (const schematic of schematics) {
+			assert(schematic.realHeight === realHeight);
+			lastPoint = context
+				.drawSchematic(schematic, lastPoint)
+				.pad(0n, 1n)
+				.getTopRight();
+		}
+
+		return context;
+	}
+
+	// eslint-disable-next-line max-params
+	static pad(
+		schematic: Schematic,
+		top: bigint,
+		right: bigint,
+		bottom: bigint,
+		left: bigint,
+	) {
+		const context = new GenerationContext(
+			schematic.realWidth + left + right,
+			schematic.realHeight + top + bottom,
+		);
+
+		context.drawSchematic(schematic, new Point(left, top));
+
+		return context;
+	}
+
+	readonly bounds: AnchorBox;
+	transparentDrawing = false;
+
+	constructor(
+		width: bigint,
+		height: bigint,
+		tiles = Array.from<unknown, tileType.QuadTreeTileType>(
+			// eslint-disable-next-line @internal/no-object-literals
+			{
+				length: asNumber(width * height),
+			},
+			() => tileType.empty,
+		),
+	) {
+		super(width, height, tiles);
+		this.bounds = new AnchorBox(new Point(0n, 0n), width, height);
+	}
+
+	drawTile(tile: tileType.QuadTreeTileType, point: Point) {
+		assert(point.x >= 0n && point.x < this.width);
+		assert(point.y >= 0n && point.y < this.height);
+
+		if (!this.transparentDrawing || tile !== tileType.empty) {
+			this.tiles[asNumber(point.y * this.width + point.x)] = tile;
+		}
+	}
+
+	repeatTileUntil(
+		tile: tileType.QuadTreeTileType,
+		topLeft: Point,
+		bottomRight: Point,
+	) {
+		return this.drawSchematic(
+			GenerationContext.repeatTileFor(
+				tile,
+				bottomRight.x - topLeft.x + 1n,
+				bottomRight.y - topLeft.y + 1n,
+			),
+			topLeft,
+		);
+	}
+
+	drawSchematic(schematic: Schematic, topLeft: Point) {
+		assert(
+			topLeft.x >= 0n && topLeft.x + schematic.realWidth <= this.width,
+		);
+		assert(
+			topLeft.y >= 0n && topLeft.y + schematic.realHeight <= this.height,
+		);
+
+		for (let y = 0n; y < schematic.height; y++) {
+			for (let x = 0n; x < schematic.width; x++) {
+				this.drawTile(
+					schematic.transformTile(x, y),
+					schematic.transformPoint(x, y, topLeft),
+				);
+			}
+		}
+
+		return new AnchorBox(
+			topLeft,
+			schematic.realWidth,
+			schematic.realHeight,
+		);
+	}
+
+	repeatSchematicUntil(
+		schematic: Schematic,
+		topLeft: Point,
+		bottomRight: Point,
+	) {
+		return this.drawSchematic(
+			GenerationContext.repeatSchematicFor(
+				schematic,
+				toBigInt(
+					(bottomRight.x - topLeft.x + 1n) / schematic.realWidth,
+				),
+				toBigInt(
+					(bottomRight.y - topLeft.y + 1n) / schematic.realHeight,
+				),
+			),
+			topLeft,
+		);
+	}
+}
+
+const gridRightActive = new GenerationContext(4n, 2n, [
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinS,
+	tileType.disjoinN,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
+const gridLeftActive = new GenerationContext(4n, 2n, [
+	tileType.empty,
+	tileType.disjoinN,
+	tileType.conjoinS,
+	tileType.conjoinS,
+
+	tileType.conjoinE,
+	tileType.negate,
+	tileType.conjoinE,
+	tileType.negate,
+]);
+
+const gridConjoin = new GenerationContext(1n, 2n, [
+	tileType.empty,
+	tileType.conjoinE,
+]);
+
+const gridIo = new GenerationContext(1n, 2n, [tileType.empty, tileType.io]);
+
+const gridNegate = new GenerationContext(1n, 2n, [
+	tileType.empty,
+	tileType.negate,
+]);
+
+const gridVerticalDoubleInput = new GenerationContext(4n, 3n, [
+	tileType.empty,
+	tileType.empty,
+	tileType.empty,
+	tileType.io,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.conjoinW,
+	tileType.disjoinN,
+
+	tileType.empty,
+	tileType.conjoinS,
+	tileType.empty,
+	tileType.negate,
+]);
+
+function drawGrid(activation: boolean[][]) {
 	const activationMapped = activation.map((row, index, {length}) => {
 		const base = (length - index) % 2 === 0;
-		return row.map((i) => i === base).flatMap((i) => [i, !i]);
+		return row.map((i) => (i === base ? gridRightActive : gridLeftActive));
 	});
 
-	for (let y = 0n; y < p; y++) {
-		// Western conjoins
-		drawTile(schematic, xOffset - 1n, 2n * y + yOffset, tileType.conjoinE);
-
-		// Grid
-		for (let x = 0n; x < 2n * q; x++) {
-			drawTile(
-				schematic,
-				2n * x + xOffset,
-				2n * y + yOffset,
-				tileType.negate,
-			);
-
-			drawTile(
-				schematic,
-				2n * x + xOffset + 1n,
-				2n * y + yOffset,
-				tileType.conjoinE,
-			);
-
-			drawTile(
-				schematic,
-				2n * x + xOffset,
-				2n * y + yOffset - 1n,
-				nonNullable(activationMapped[asNumber(y)])[asNumber(x)]
-					? tileType.disjoinS
-					: tileType.conjoinN,
-			);
-		}
-
-		// Downward conjoins in grid
-		for (let x = 0n; x < q; x++) {
-			drawTile(
-				schematic,
-				4n * x + xOffset + 1n,
-				2n * y + yOffset - 1n,
-				tileType.conjoinS,
-			);
-		}
-	}
-
-	// Southern IO
-	for (let x = 0n; x < q; x++) {
-		drawTile(
-			schematic,
-			4n * x + xOffset,
-			2n * p + yOffset - 1n,
-			tileType.conjoinN,
-		);
-		drawTile(
-			schematic,
-			4n * x + xOffset + 2n,
-			2n * p + yOffset - 1n,
-			tileType.conjoinN,
-		);
-
-		drawTile(
-			schematic,
-			4n * x + xOffset,
-			2n * p + yOffset,
-			tileType.conjoinN,
-		);
-		drawTile(
-			schematic,
-			4n * x + xOffset + 1n,
-			2n * p + yOffset,
-			tileType.negate,
-		);
-		drawTile(
-			schematic,
-			4n * x + xOffset + 2n,
-			2n * p + yOffset,
-			tileType.disjoinS,
-		);
-
-		drawTile(
-			schematic,
-			4n * x + xOffset + 2n,
-			2n * p + yOffset + 1n,
-			tileType.io,
-		);
-	}
+	return GenerationContext.horizontalJoin(
+		GenerationContext.repeatSchematicFor(
+			activationMapped.flat(),
+			asBigInt(nonNullable(activationMapped[0]).length),
+			asBigInt(activationMapped.length),
+		),
+		GenerationContext.repeatSchematicFor(
+			gridConjoin,
+			1n,
+			asBigInt(activationMapped.length),
+		),
+	);
 }
 
-// eslint-disable-next-line max-params
 function drawIoBridge(
-	schematic: Schematic,
-	x: bigint,
-	xDir: -1n | 1n,
-	yStart: bigint,
-	yEnd: bigint,
-	north: typeof tileType.conjoinN | typeof tileType.disjoinN,
+	rows: bigint,
+	type:
+		| typeof tileType.conjoinN
+		| typeof tileType.disjoinN
+		| typeof tileType.negate
+		| typeof tileType.io,
 ) {
-	const yMid = toBigInt((yStart + yEnd) / 2n);
-
-	for (let y = yStart; y < yEnd; y++) {
-		// Cast safety: (north + 0) is north and (north + 2) is south.
-		drawTile(
-			schematic,
-			x,
-			y,
-			(north + (y < yMid ? 2 : 0)) as tileType.QuadTreeTileType,
-		);
+	if (type === tileType.negate) {
+		return GenerationContext.repeatSchematicFor(gridNegate, 1n, rows);
 	}
 
-	// Cast safety: (north + 3) is west and (north + 1) is east.
-	drawTile(
-		schematic,
-		x,
-		yMid,
-		(north + (xDir < 0 ? 3 : 1)) as tileType.QuadTreeTileType,
+	if (type === tileType.io) {
+		return GenerationContext.repeatSchematicFor(gridIo, 1n, rows);
+	}
+
+	const context = new GenerationContext(2n, rows * gridConjoin.realHeight);
+
+	context.repeatTileUntil(
+		type === tileType.conjoinN ? tileType.conjoinS : tileType.disjoinS,
+		context.bounds.pad(-1n, 0n).topLeft,
+		context.bounds.getLeft(),
 	);
 
-	drawTile(schematic, x + xDir, yMid, tileType.io);
+	context.repeatTileUntil(
+		type === tileType.conjoinN ? tileType.conjoinN : tileType.disjoinN,
+		context.bounds.getLeft(),
+		context.bounds.getBottomLeft(),
+	);
+
+	context.drawTile(
+		type === tileType.conjoinN ? tileType.conjoinE : tileType.disjoinE,
+		context.bounds.getLeft(),
+	);
+
+	context.drawTile(tileType.io, context.bounds.getRight());
+
+	context.horizontalReflection = type === tileType.disjoinN;
+
+	return context;
 }
 
-function createEmptySchema(width: bigint, height: bigint) {
-	/* eslint-disable @internal/no-object-literals */
-	return new Schematic(
-		width,
-		height,
-		Array.from<tileType.QuadTreeTileType>({
-			length: asNumber(width * height),
-		}).fill(tileType.empty),
+export function drawEncoderBridge(output: bigint) {
+	assert(output > 0n);
+
+	const rowsPerBit = 2n ** (output - 1n);
+	const context = new GenerationContext(
+		2n,
+		((rowsPerBit - 1n) * output + 2n) * gridConjoin.realHeight,
 	);
-	/* eslint-enable @internal/no-object-literals */
+	let lastPoint = context.bounds.topLeft;
+
+	context.transparentDrawing = true;
+
+	for (let i = 0n; i < output; i++) {
+		const bounds = context
+			.drawSchematic(
+				drawIoBridge(rowsPerBit, tileType.conjoinN),
+				lastPoint,
+			)
+			.pad(-1n, 0n);
+
+		if (i > 0n) {
+			context.drawTile(tileType.disjoinW, bounds.topLeft);
+		}
+
+		lastPoint = bounds.getBottomLeft();
+	}
+
+	context.drawSchematic(
+		drawIoBridge(1n, tileType.conjoinN),
+		context.bounds.pad(-1n, 0n).getBottomLeft(),
+	);
+
+	return context;
 }
 
 export function generateMultiplexer(input: bigint, output: bigint) {
 	assert(minBigInt(input, output) === 1n);
 	const p = maxBigInt(input, output);
 	const q = asBigInt(Math.ceil(Math.log2(asNumber(p))));
-	const width = 4n * q + 4n;
-	const height = 2n * p + 4n;
-	const xOffset = input > output ? 2n : 3n;
-	const yOffset = 2n;
 
-	const schematic = createEmptySchema(width, height);
-
-	drawGrid(
-		schematic,
+	const grid = drawGrid(
 		// eslint-disable-next-line @internal/no-object-literals
 		Array.from({length: asNumber(p)}, (_, index) =>
 			index
@@ -177,51 +426,42 @@ export function generateMultiplexer(input: bigint, output: bigint) {
 				.split('')
 				.map((i) => i === '1'),
 		),
-		xOffset,
-		yOffset,
 	);
 
-	// Northern IO
-	for (let x = 0n; x < 2n * q; x++) {
-		drawTile(schematic, 2n * x + xOffset, yOffset - 2n, tileType.io);
-	}
-
-	// Input IO
-	for (let y = 0n; y < p; y++) {
-		drawTile(
-			schematic,
-			input > output ? 0n : width - 1n,
-			2n * y + yOffset,
-			tileType.io,
-		);
-	}
-
-	// Output IO
-	drawIoBridge(
-		schematic,
-		input > output ? width - 2n : 1n,
-		input > output ? 1n : -1n,
-		yOffset,
-		2n * p + yOffset - 1n,
-		input > output ? tileType.conjoinN : tileType.disjoinN,
+	const dataIn = drawIoBridge(
+		p,
+		input > output ? tileType.io : tileType.disjoinN,
 	);
 
-	return schematic;
+	const dataOut = drawIoBridge(
+		p,
+		input > output ? tileType.conjoinN : tileType.io,
+	);
+
+	const selector = GenerationContext.repeatSchematicFor(
+		gridVerticalDoubleInput,
+		q,
+		1n,
+	);
+
+	return GenerationContext.verticalJoin(
+		GenerationContext.pad(
+			selector,
+			0n,
+			dataOut.realWidth + 1n,
+			0n,
+			dataIn.realWidth,
+		),
+		GenerationContext.horizontalJoin(dataIn, grid, dataOut),
+	);
 }
 
 export function generateDecoder(input: bigint, output: bigint) {
 	assert(output <= 2n ** input);
 	const p = output;
 	const q = input;
-	const width = 4n * q + 3n;
-	const height = 2n * p + 3n;
-	const xOffset = 2n;
-	const yOffset = 1n;
 
-	const schematic = createEmptySchema(width, height);
-
-	drawGrid(
-		schematic,
+	const grid = drawGrid(
 		// eslint-disable-next-line @internal/no-object-literals
 		Array.from({length: asNumber(p)}, (_, index) =>
 			index
@@ -230,19 +470,28 @@ export function generateDecoder(input: bigint, output: bigint) {
 				.split('')
 				.map((i) => i === '1'),
 		),
-		xOffset,
-		yOffset,
 	);
 
-	for (let y = 0n; y < p; y++) {
-		// Western Negate
-		drawTile(schematic, 0n, 2n * y + yOffset, tileType.negate);
+	const dataIn = drawIoBridge(p, tileType.negate);
 
-		// Output IO
-		drawTile(schematic, width - 1n, 2n * y + yOffset, tileType.io);
-	}
+	const dataOut = drawIoBridge(p, tileType.io);
 
-	return schematic;
+	const selector = GenerationContext.repeatSchematicFor(
+		gridVerticalDoubleInput,
+		q,
+		1n,
+	);
+
+	return GenerationContext.verticalJoin(
+		GenerationContext.pad(
+			selector,
+			0n,
+			dataOut.realWidth + 1n,
+			0n,
+			dataIn.realWidth,
+		),
+		GenerationContext.horizontalJoin(dataIn, grid, dataOut),
+	);
 }
 
 export function generateEncoder(input: bigint, output: bigint) {
@@ -269,55 +518,35 @@ export function generateEncoder(input: bigint, output: bigint) {
 
 	const p = asBigInt(activation.length);
 	const q = input;
-	const width = 4n * q + 4n;
-	const height = 2n * p + 3n;
-	const xOffset = 2n;
-	const yOffset = 1n;
 
-	const schematic = createEmptySchema(width, height);
-
-	drawGrid(
-		schematic,
-		activation.map((i) =>
-			i
+	const grid = drawGrid(
+		activation.map((value) =>
+			value
 				.toString(2)
 				.padStart(asNumber(q), '0')
 				.split('')
 				.map((i) => i === '1'),
 		),
-		xOffset,
-		yOffset,
 	);
 
-	for (let y = 0n; y < p; y++) {
-		// Western Negate
-		drawTile(schematic, 0n, 2n * y + yOffset, tileType.negate);
-	}
+	const dataIn = drawIoBridge(p, tileType.negate);
 
-	const outputParts = toBigInt(q / 2n);
+	const dataOut = drawEncoderBridge(output);
 
-	for (let i = 0n; i < output; i++) {
-		drawIoBridge(
-			schematic,
-			width - 2n,
-			1n,
-			2n * (outputParts - 1n) * i + yOffset,
-			2n * (outputParts - 1n) * (i + 1n) + yOffset + 1n,
-			tileType.conjoinN,
-		);
+	const selector = GenerationContext.repeatSchematicFor(
+		gridVerticalDoubleInput,
+		q,
+		1n,
+	);
 
-		if (i > 0n) {
-			drawTile(
-				schematic,
-				width - 2n,
-				2n * (outputParts - 1n) * i + yOffset,
-				tileType.disjoinW,
-			);
-		}
-	}
-
-	drawTile(schematic, width - 2n, schematic.height - 4n, tileType.conjoinE);
-	drawTile(schematic, width - 1n, schematic.height - 4n, tileType.io);
-
-	return schematic;
+	return GenerationContext.verticalJoin(
+		GenerationContext.pad(
+			selector,
+			0n,
+			dataOut.realWidth + 1n,
+			0n,
+			dataIn.realWidth,
+		),
+		GenerationContext.horizontalJoin(dataIn, grid, dataOut),
+	);
 }

--- a/src/lib/schematic.ts
+++ b/src/lib/schematic.ts
@@ -60,7 +60,7 @@ export class Schematic {
 	constructor(
 		readonly width: number,
 		readonly height: number,
-		readonly tiles: readonly tileType.QuadTreeTileType[],
+		readonly tiles: tileType.QuadTreeTileType[],
 	) {}
 
 	transformPoint(x: number, y: number, topLeft: Point) {

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -1,6 +1,6 @@
 import {QuadTreeBoundingBox, AxisAlignedBoundingBox} from './aabb.js';
 import {assert, assertArray, assertObject} from './assert.js';
-import {roundedSqrt} from './bigint.js';
+import {asNumber, roundedSqrt} from './bigint.js';
 import {QuadTreeNode} from './node.js';
 import {Point} from './point.js';
 import {Schematic} from './schematic.js';
@@ -98,7 +98,7 @@ export class QuadTree {
 	getSchematic(display: AxisAlignedBoundingBox): Schematic {
 		// eslint-disable-next-line @internal/no-object-literals
 		const tiles = Array.from<tileType.QuadTreeTileType>({
-			length: Number(display.width * display.height),
+			length: asNumber(display.width * display.height),
 		}).fill(tileType.empty);
 
 		const progress: WalkStep[] = [
@@ -131,10 +131,10 @@ export class QuadTree {
 				continue;
 			}
 
-			const i = Number(node.bounds.topLeft.x - display.topLeft.x);
-			const j = Number(node.bounds.topLeft.y - display.topLeft.y);
+			const i = node.bounds.topLeft.x - display.topLeft.x;
+			const j = node.bounds.topLeft.y - display.topLeft.y;
 
-			tiles[i + j * Number(display.width)] = node.type;
+			tiles[asNumber(i + j * display.width)] = node.type;
 
 			progress.pop();
 
@@ -145,24 +145,20 @@ export class QuadTree {
 			}
 		}
 
-		return new Schematic(
-			Number(display.width),
-			Number(display.height),
-			tiles,
-		);
+		return new Schematic(display.width, display.height, tiles);
 	}
 
 	putSchematic(schematic: Schematic, topLeft: Point) {
 		const display = new AxisAlignedBoundingBox(
 			topLeft,
-			BigInt(schematic.realWidth),
-			BigInt(schematic.realHeight),
+			schematic.realWidth,
+			schematic.realHeight,
 		);
 
 		const root = this.getContainingNode(display, searchMode.make);
 
-		for (let y = 0; y < schematic.height; y++) {
-			for (let x = 0; x < schematic.width; x++) {
+		for (let y = 0n; y < schematic.height; y++) {
+			for (let x = 0n; x < schematic.width; x++) {
 				// Cast safety: Point is always inside the display, and root
 				// contains the display.
 				root.getTileData(

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,7 @@
 /* eslint-disable import/no-unassigned-import */
 import 'vite/client';
+
+declare global {
+	// eslint-disable-next-line no-var, @typescript-eslint/naming-convention
+	var RISG_BIGINT: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,13 +15,15 @@ export default defineConfig(({mode}) => ({
 	cacheDir: 'node_modules/.cache/vite',
 	build: {
 		target: ['firefox103', 'chrome104'],
-		outDir: 'build',
-		rollupOptions: {
-			input: [
-				'index.html',
-				process.env.RISG_CLI ? 'src/cli.ts' : '',
-			].filter(Boolean),
-		},
+		outDir: process.env.RISG_CLI ? 'build/cli' : 'build',
+		rollupOptions: process.env.RISG_CLI
+			? {
+					input: {cli: 'src/cli.ts'},
+					output: {entryFileNames: 'index.js'},
+			  }
+			: {
+					input: ['index.html'],
+			  },
 		modulePreload: {
 			polyfill: false,
 		},


### PR DESCRIPTION
You can generate them by running `./cli -g mem4x8` where `4` is the address space width in bits, and `8` is the data space width in bits.

I have completely refactored the generation script. It now uses a subclass of `Schematic` to generate the output. It now builds its parts in separate steps, rather than working on a shared canvas. It is much easier to reason about what the code is doing now, I hope.

I have also fixed the `./cli` script to always build the CLI (now in its own directory!) before running it. Using it is much less painful now.

As an aside, the code now has very clear functions to convert between the source-only `BigInt`s and `Number`s. This makes the output slightly smaller, since `asNumber` and `asBigInt` function calls are entirely elided.